### PR TITLE
python: Drop 3.6 in favor of python 3.10 support

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,9 +13,9 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
       with:
-        python-version: '3.9'
+        python-version: '3.10'
         architecture: x64
     - run: pip install --constraint=.github/workflows/constraints.txt nox
     - run: pip install --constraint=.github/workflows/constraints.txt poetry
-    - run: nox --sessions tests-3.9 coverage
+    - run: nox --sessions tests-3.10 coverage
     - run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - { python-version: 3.9, os: ubuntu-latest }
-          - { python-version: 3.9, os: macos-latest }
-          - { python-version: 3.8, os: ubuntu-latest }
-          - { python-version: 3.7, os: ubuntu-latest }
-          - { python-version: 3.6, os: ubuntu-latest }
+          - { python-version: '3.10', os: ubuntu-latest }
+          - { python-version: '3.10', os: macos-latest }
+          - { python-version: '3.9', os: ubuntu-latest }
+          - { python-version: '3.8', os: ubuntu-latest }
+          - { python-version: '3.7', os: ubuntu-latest }
     name: Python ${{ matrix.python-version }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ import nox
 from nox.sessions import Session
 
 package: str = "github_release_fetcher"
-python: List[str] = ["3.9", "3.8", "3.7", "3.6"]
+python: List[str] = ["3.10", "3.9", "3.8", "3.7"]
 locations = "src", "tests", "noxfile.py"
 
 nox.options.sessions = "lint", "mypy", "safety", "tests"
@@ -28,7 +28,7 @@ def install_with_constraints(session: Session, *args: str, **kwargs: Any) -> Non
         session.install(f"--constraint={requirements.name}", *args, **kwargs)
 
 
-@nox.session(python=["3.9"])
+@nox.session(python=["3.10"])
 def black(session: Session) -> None:
     """Run black code formatter."""
     args = session.posargs or locations
@@ -36,7 +36,7 @@ def black(session: Session) -> None:
     session.run("black", *args)
 
 
-@nox.session(python=["3.9"])
+@nox.session(python=["3.10"])
 def coverage(session: Session) -> None:
     """Generate coverage data."""
     install_with_constraints(session, "coverage[toml]")
@@ -62,7 +62,7 @@ def lint(session: Session) -> None:
     session.run("flake8", *args)
 
 
-@nox.session(python=["3.9"])
+@nox.session(python=["3.10"])
 def mypy(session: Session) -> None:
     """Run static type checks using mypy."""
     args = session.posargs or locations
@@ -70,7 +70,7 @@ def mypy(session: Session) -> None:
     session.run("mypy", *args)
 
 
-@nox.session(python=["3.9"])
+@nox.session(python=["3.10"])
 def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
     with tempfile.NamedTemporaryFile() as requirements:
@@ -96,7 +96,7 @@ def tests(session: Session) -> None:
     session.run("pytest", *args)
 
 
-@nox.session(python=["3.9"])
+@nox.session(python=["3.10"])
 def typeguard(session: Session) -> None:
     """Run dynamic type checks with typeguard."""
     args = session.posargs or ["-m", "not e2e"]
@@ -105,7 +105,7 @@ def typeguard(session: Session) -> None:
     session.run("pytest", f"--typeguard-packages={package}", *args)
 
 
-@nox.session(python=["3.9"])
+@nox.session(python=["3.10"])
 def xdoctest(session: Session) -> None:
     """Run examples from docstring with xdoctest."""
     args = session.posargs or ["all"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ keywords = ["github"]
 authors = ["Patrick Ziegler <ziggo@zaebos.de>"]
 
 [tool.poetry.dependencies]
-python = "^3.6.1"
+python = "^3.7"
 click = "^8.0.4"
 requests = "^2.27.1"
 


### PR DESCRIPTION
Python version 3.6 has reached EOL, so drop it and add the latext
version 3.10 instead.
