### PR TITLE
ci: Select python version to run tests on

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,4 +43,4 @@ jobs:
         architecture: x64
     - run: pip install --constraint=.github/workflows/constraints.txt nox
     - run: pip install --constraint=.github/workflows/constraints.txt poetry
-    - run: nox
+    - run: nox --pythons '${{ matrix.python-version }}'


### PR DESCRIPTION
In the current configuration, nox tries every python version on every
action even though only a specific python version is available.

With this change, only the tests for the relevant python version is being
executed.
